### PR TITLE
최근 접속한 클라이언트 수를 기록합니다

### DIFF
--- a/src/main/java/org/kish/ContainerConfig.java
+++ b/src/main/java/org/kish/ContainerConfig.java
@@ -6,11 +6,13 @@
 package org.kish;
 
 import org.apache.catalina.connector.Connector;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -20,6 +22,8 @@ import java.io.File;
 public class ContainerConfig implements WebMvcConfigurer {
     @Value("${ajp.port}")
     int ajpPort;
+    @Autowired
+    public Interceptor interceptor;
 
     @Bean
     public ServletWebServerFactory servletContainer() {
@@ -42,5 +46,11 @@ public class ContainerConfig implements WebMvcConfigurer {
         registry
                 .addResourceHandler("/resource/**")
                 .addResourceLocations("file:" + KishServer.RESOURCE_PATH.getAbsolutePath() + File.separator);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(interceptor)
+                .addPathPatterns("/**");
     }
 }

--- a/src/main/java/org/kish/Interceptor.java
+++ b/src/main/java/org/kish/Interceptor.java
@@ -11,14 +11,14 @@ import java.util.concurrent.ConcurrentHashMap;
 @Log4j2
 @Component
 public class Interceptor extends HandlerInterceptorAdapter {
-    public ConcurrentHashMap<String, Long> sessions = new ConcurrentHashMap<>();
+    public ConcurrentHashMap<String, Long> clients = new ConcurrentHashMap<>();
 
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
         super.afterCompletion(request, response, handler, ex);
 
         long current = System.currentTimeMillis();
-        sessions.put(request.getRemoteAddr(), current);
+        clients.put(request.getRemoteAddr(), current);
 
         StringBuilder sb = new StringBuilder();
         sb.append("url=[").append(request.getRequestURI())

--- a/src/main/java/org/kish/Interceptor.java
+++ b/src/main/java/org/kish/Interceptor.java
@@ -1,0 +1,29 @@
+package org.kish;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Log4j2
+@Component
+public class Interceptor extends HandlerInterceptorAdapter {
+    public ConcurrentHashMap<String, Long> sessions = new ConcurrentHashMap<>();
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        super.afterCompletion(request, response, handler, ex);
+
+        long current = System.currentTimeMillis();
+        sessions.put(request.getRemoteAddr(), current);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("url=[").append(request.getRequestURI())
+                .append("]; client=[").append(request.getRemoteAddr())
+                .append("];");
+        MainLogger.info(sb.toString());
+    }
+}

--- a/src/main/java/org/kish/KishServer.java
+++ b/src/main/java/org/kish/KishServer.java
@@ -109,9 +109,4 @@ public class KishServer {
     public FirebaseManager getFirebaseManager(){
         return firebaseManager;
     }
-
-    @EventListener
-    public void requestEventListener(RequestHandledEvent e){
-        MainLogger.info(e.getShortDescription() + "(" + e.getProcessingTimeMillis() + "ms)");
-    }
 }

--- a/src/main/java/org/kish/Scheduler.java
+++ b/src/main/java/org/kish/Scheduler.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+
 @Component
 public class Scheduler {
     @Autowired
@@ -15,6 +17,8 @@ public class Scheduler {
     public PostApiController postApiController;
     @Autowired
     public KishMagazineApiController kishMagazineApiController;
+    @Autowired
+    public Interceptor interceptor;
 
     @Scheduled(fixedDelay = 1000 * 60 * 10, initialDelay = 1000 * 60)
     public void updateLunchMenu() {
@@ -34,5 +38,29 @@ public class Scheduler {
     @Scheduled(fixedDelay = 1000 * 60 * 30, initialDelay = 1000 * 60 * 30)
     public void updateKishMagazine() {
         kishMagazineApiController.updateArticles();
+    }
+
+    @Scheduled(fixedDelay = 1000 * 60 * 10)
+    public void SessionMonitor() {
+        int in10min = 0;
+        int in1Hour = 0;
+
+        ArrayList<String> list = new ArrayList<>();
+        long current = System.currentTimeMillis();
+        for (String ip : interceptor.sessions.keySet()) {
+            long time = interceptor.sessions.get(ip);
+            long diff = current - time;
+
+            if (diff > 1000 * 60 * 60) {
+                list.add(ip);
+            } else {
+                if (diff <= 1000 * 60 * 10) {
+                    in10min++;
+                }
+                in1Hour++;
+            }
+        }
+
+        MainLogger.info("sessions: " + in1Hour + " (1h), " + in10min + " (10m)");
     }
 }

--- a/src/main/java/org/kish/Scheduler.java
+++ b/src/main/java/org/kish/Scheduler.java
@@ -41,14 +41,14 @@ public class Scheduler {
     }
 
     @Scheduled(fixedDelay = 1000 * 60 * 10)
-    public void SessionMonitor() {
+    public void clientMonitor() {
         int in10min = 0;
         int in1Hour = 0;
 
         ArrayList<String> list = new ArrayList<>();
         long current = System.currentTimeMillis();
-        for (String ip : interceptor.sessions.keySet()) {
-            long time = interceptor.sessions.get(ip);
+        for (String ip : interceptor.clients.keySet()) {
+            long time = interceptor.clients.get(ip);
             long diff = current - time;
 
             if (diff > 1000 * 60 * 60) {
@@ -61,6 +61,6 @@ public class Scheduler {
             }
         }
 
-        MainLogger.info("sessions: " + in1Hour + " (1h), " + in10min + " (10m)");
+        MainLogger.info("Clients: " + in1Hour + " (1h), " + in10min + " (10m)");
     }
 }


### PR DESCRIPTION
최근 1시간, 10분간 접속한 클라이언트의 수를 기록하고 모니터링 할 수 있도록 로그에 남기는 기능을 추가하였습니다.
아이피를 통해 클라이언트를 구분하기 위하여 기존에 사용하던 EventListener를 제거하고 HandlerInterceptorAdapter를 이용하였습니다.

약 10분을 주기로 아래와 같은 메세지를 출력할 것입니다.
```
Clients: 6 (1h), 3 (10m)
```