### PR TITLE
첨부파일 base url 지정 기능 추가

### DIFF
--- a/src/main/java/org/kish/config/ConfigOption.java
+++ b/src/main/java/org/kish/config/ConfigOption.java
@@ -19,7 +19,8 @@ public enum ConfigOption {
     SPRING_AJP_PORT("tomcat_apj_port", 8009),
     JOD_PORT("jod_converter_port", 2002L),
 
-    RESOURCE_PATH("resource_path", "./resource/");
+    RESOURCE_PATH("resource_path", "./resource/"),
+    DOWNLAOD_BASE_URL("download_base_url", "http://www.hanoischool.net/");
 
     private final String key;
     private final Object defValue;

--- a/src/main/java/org/kish/config/ConfigOption.java
+++ b/src/main/java/org/kish/config/ConfigOption.java
@@ -20,7 +20,7 @@ public enum ConfigOption {
     JOD_PORT("jod_converter_port", 2002L),
 
     RESOURCE_PATH("resource_path", "./resource/"),
-    DOWNLAOD_BASE_URL("download_base_url", "http://www.hanoischool.net/");
+    DOWNLAOD_BASE_URL("download_base_url", "http://hanoischool.net/");
 
     private final String key;
     private final Object defValue;

--- a/src/main/java/org/kish/utils/parser/KishWebParser.java
+++ b/src/main/java/org/kish/utils/parser/KishWebParser.java
@@ -19,7 +19,7 @@ import java.util.Calendar;
 import java.util.LinkedHashMap;
 
 public class KishWebParser {
-    public static final String ROOT_URL = "http://www.hanoischool.net/";
+    public static final String BASE_URL = "http://www.hanoischool.net/";
 
     public static ArrayList<LunchMenu> parseLunch(){
         return parseLunch("");
@@ -28,7 +28,7 @@ public class KishWebParser {
     public static ArrayList<LunchMenu> parseLunch(String changeDate){
         ArrayList<LunchMenu> list = new ArrayList<>();
         try {
-            Document doc = Jsoup.connect(ROOT_URL + "?menu_no=47&ChangeDate=" + changeDate).get();
+            Document doc = Jsoup.connect(BASE_URL + "?menu_no=47&ChangeDate=" + changeDate).get();
             Elements items = doc.select(".h_line_dot");
             items.addAll(doc.select(".h_line_color"));
 
@@ -87,7 +87,7 @@ public class KishWebParser {
 
     public static ArrayList<SimplePost> parseMenu(String menuId, String page){
         ArrayList<SimplePost> list = new ArrayList<>();
-        String url = ROOT_URL + "?menu_no=" + menuId + "&page=" + page;
+        String url = BASE_URL + "?menu_no=" + menuId + "&page=" + page;
         try {
             Document doc = Jsoup.connect(url).get();
             Elements items = doc.select(".h_line_dot");
@@ -113,7 +113,7 @@ public class KishWebParser {
                 String postDate = elements.get(3).text();
 
                 String attachmentIconUrl = elements.select("img").attr("src");
-                String postUrl = ROOT_URL + elements.select("a").attr("href");
+                String postUrl = BASE_URL + elements.select("a").attr("href");
 
                 list.add(
                         new SimplePost(postUrl, Integer.parseInt(menuId), Integer.parseInt(postId), title, author, postDate, attachmentIconUrl));
@@ -174,7 +174,7 @@ public class KishWebParser {
                         if (downloadBaseUrl.charAt(downloadBaseUrl.length() - 1) != '/') {
                             downloadBaseUrl += "/";
                         }
-                        href = href.replace(ROOT_URL, downloadBaseUrl);
+                        href = href.replace(BASE_URL, downloadBaseUrl);
                     }
 
                     post.addAttachment(element.text(), href);

--- a/src/main/java/org/kish/utils/parser/KishWebParser.java
+++ b/src/main/java/org/kish/utils/parser/KishWebParser.java
@@ -19,7 +19,7 @@ import java.util.Calendar;
 import java.util.LinkedHashMap;
 
 public class KishWebParser {
-    public static final String BASE_URL = "http://www.hanoischool.net/";
+    public static final String BASE_URL = "http://hanoischool.net/";
 
     public static ArrayList<LunchMenu> parseLunch(){
         return parseLunch("");

--- a/src/main/java/org/kish/utils/parser/KishWebParser.java
+++ b/src/main/java/org/kish/utils/parser/KishWebParser.java
@@ -5,7 +5,9 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.kish.KishServer;
 import org.kish.MainLogger;
+import org.kish.config.ConfigOption;
 import org.kish.entity.LunchMenu;
 import org.kish.entity.Post;
 import org.kish.entity.SimplePost;
@@ -165,7 +167,17 @@ public class KishWebParser {
             post.setHasAttachments(attachmentElements.size());
             if(attachmentElements.size() > 0){
                 attachmentElements.forEach(element -> {
-                    post.addAttachment(element.text(), element.attr("href"));
+                    String href = element.attr("href");
+
+                    if (KishServer.CONFIG != null) {
+                        String downloadBaseUrl = (String) KishServer.CONFIG.get(ConfigOption.DOWNLAOD_BASE_URL);
+                        if (downloadBaseUrl.charAt(downloadBaseUrl.length() - 1) != '/') {
+                            downloadBaseUrl += "/";
+                        }
+                        href = href.replace(ROOT_URL, downloadBaseUrl);
+                    }
+
+                    post.addAttachment(element.text(), href);
                 });
             }
         } catch (IOException e) {


### PR DESCRIPTION
# 개요
이 PR은 첨부파일의 base url을 지정할 수 있는 기능을 추가합니다.

# 이 PR은...
현재 학교 홈페이지의 이슈 중 하나로, 일부 브라우저에서 pdf와 같은 파일들이 다운로드 되지 않고 텍스트로 노출되는 경우가 존재합니다. 
이 이슈는 비교적 최신버전의 크로미움 기반 브라우저에선 수정된 듯 보이지만, 사파리에선 여전히 발생하고 있습니다.

서버 관리자는 학교 홈페이지를 리버스 프록시 호스트를 만들고, 헤더의 Content-Type을 강제로 변경하여 이슈를 해결할 수 있으며, KISH 컨피그 파일의 ``download_base_url``의 값을 수정하여 클라이언트가 본인의 프록시 서버를 통해 첨부파일을 다운로드 하도록 할 수 있습니다.

# 변경사항
- Config에  download_base_url 옵션이 추가되었습니다. 기본값은 ``http://hanoischool.net/``입니다.
- ``KishWebParser``클래스의 ``ROOT_URL`` 변수의 이름이 ``BASE_URL``으로 변경되었습니다.
- BASE_URL변수의 값이 ``http://hanoischool.net/`` 으로 변경되었습니다.