### PR TITLE
KISH MAGAZINE 코로나 관련 요소 필터링

### DIFF
--- a/src/main/java/org/kish/web/KishMagazineApiController.java
+++ b/src/main/java/org/kish/web/KishMagazineApiController.java
@@ -128,7 +128,9 @@ public class KishMagazineApiController {
 
     @GetMapping(value = "home")
     @ResponseBody
-    public String homeApi(@RequestParam String parent, @RequestParam String category, @RequestParam(required = false, defaultValue = "false") boolean ios) {
+    public String homeApi(@RequestParam String parent,
+                          @RequestParam String category,
+                          @RequestParam(required = false, defaultValue = "false") boolean ios) {
         if (category.equals("all")) {
             ArrayList<Object> result = new ArrayList<>();
             for (Object childCategory : gson.fromJson(getCategoryListApi(parent), ArrayList.class)) {


### PR DESCRIPTION
ios 클라이언트에게 코로나 관련 기사 및 이미지를 숨깁니다.

ios의 경우 정책상 코로나 관련 기사를 표시해선 안 됩니다.